### PR TITLE
根据4.7日更新代码，解决冲突

### DIFF
--- a/knowledge_based_chatglm.py
+++ b/knowledge_based_chatglm.py
@@ -10,11 +10,16 @@ from langchain.vectorstores import FAISS
 from langchain.document_loaders import UnstructuredFileLoader
 from chatglm_llm import ChatGLM
 
+embedding_model_dict = {
+    "ernie-tiny": "nghuyong/ernie-3.0-nano-zh",
+    "ernie-base": "nghuyong/ernie-3.0-base-zh",
+    "text2vec": "GanymedeNil/text2vec-large-chinese"
+}
 chatglm = ChatGLM()
 
 
 def init_knowledge_vector_store(filepath):
-    embeddings = HuggingFaceEmbeddings(model_name="GanymedeNil/text2vec-large-chinese", )
+    embeddings = HuggingFaceEmbeddings(model_name=embedding_model_dict["text2vec"], )
     loader = UnstructuredFileLoader(filepath, mode="elements")
     docs = loader.load()
 


### PR DESCRIPTION
新增ernie系列模型作为embedding model,默认依旧使用GanymedeNil/text2vec-large-chinese 显存不足时可尝试使用ernie-tiny作为embedding模型
调用方式为embeddings = HuggingFaceEmbeddings(model_name=embedding_model_dict["ernie-tiny"], )