### PR TITLE
fix: 扩展文档的代码逻辑

### DIFF
--- a/chains/local_doc_qa.py
+++ b/chains/local_doc_qa.py
@@ -73,6 +73,7 @@ def similarity_search_with_score_by_vector(
     scores, indices = self.index.search(np.array([embedding], dtype=np.float32), k)
     docs = []
     id_set = set()
+    store_len = len(self.index_to_docstore_id)
     for j, i in enumerate(indices[0]):
         if i == -1:
             # This happens when not enough docs are returned.
@@ -81,7 +82,9 @@ def similarity_search_with_score_by_vector(
         doc = self.docstore.search(_id)
         id_set.add(i)
         docs_len = len(doc.page_content)
-        for k in range(1, max(i, len(docs) - i)):
+        for k in range(1, store_len):
+            if i + k >= store_len and i - k < 0:
+                  break
             break_flag = False
             for l in [i + k, i - k]:
                 if 0 <= l < len(self.index_to_docstore_id):

--- a/chains/local_doc_qa.py
+++ b/chains/local_doc_qa.py
@@ -82,9 +82,7 @@ def similarity_search_with_score_by_vector(
         doc = self.docstore.search(_id)
         id_set.add(i)
         docs_len = len(doc.page_content)
-        for k in range(1, store_len):
-            if i + k >= store_len and i - k < 0:
-                  break
+        for k in range(1, max(i, store_len-i)):
             break_flag = False
             for l in [i + k, i - k]:
                 if 0 <= l < len(self.index_to_docstore_id):


### PR DESCRIPTION
第 84 行：

https://github.com/imClumsyPanda/langchain-ChatGLM/blob/b03634fb7c623b92457cc580dee77a432db2d6f2/chains/local_doc_qa.py#LL84C8-L84C50

`for k in range(1, max(i, len(docs) - i)):`，代码走到这里时 docs 是空数组，所以是不是写错了呀

至少某些情况下，比如 id 靠前的（如i=1）context 不能扩展到足够的长度。

试着改了下，在 colab 里测试运行没有问题