### PR TITLE
Fix 知识库无法上载,NLTK_DATA_PATH路径错误

### DIFF
--- a/configs/model_config.py
+++ b/configs/model_config.py
@@ -62,4 +62,4 @@ LLM_HISTORY_LEN = 3
 # return top-k text chunk from vector store
 VECTOR_SEARCH_TOP_K = 5
 
-NLTK_DATA_PATH = os.path.join(os.path.dirname(__file__), "nltk_data")
+NLTK_DATA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "nltk_data")


### PR DESCRIPTION
NLTK_DATA_PATH路径错误,导致知识库上传一直读条。
修复路径问题： NLTK_DATA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "nltk_data")