### PR TITLE
path bug fix

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -36,7 +36,7 @@ $ pip uninstall detectron2
 $ pip install -r requirements.txt
 
 # 验证paddleocr是否成功，首次运行会下载约18M模型到~/.paddleocr
-$ python loader/image_loader.py
+$ cd loader && python image_loader.py
 
 ```
 注：使用 `langchain.document_loaders.UnstructuredFileLoader` 进行非结构化文件接入时，可能需要依据文档进行其他依赖包的安装，请参考 [langchain 文档](https://python.langchain.com/en/latest/modules/indexes/document_loaders/examples/unstructured_file.html)。

--- a/loader/image_loader.py
+++ b/loader/image_loader.py
@@ -27,9 +27,13 @@ class UnstructuredPaddleImageLoader(UnstructuredFileLoader):
         txt_file_path = image_ocr_txt(self.file_path)
         from unstructured.partition.text import partition_text
         return partition_text(filename=txt_file_path, **self.unstructured_kwargs)
-      
-      
+
+
 if __name__ == "__main__":
+    NLTK_DATA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "nltk_data")
+    import nltk
+
+    nltk.data.path = [NLTK_DATA_PATH] + nltk.data.path
     filepath = "../content/samples/test.jpg"
     loader = UnstructuredPaddleImageLoader(filepath, mode="elements")
     docs = loader.load()


### PR DESCRIPTION
python loader/image_loader.py会报错：
No such file or directory: '../content/samples/test.jpg'
另外需要配NLTK_DATA_PATH
