### PR TITLE
Fix MOSS模型加载BUG

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pymupdf
 paddlepaddle==2.4.2
 paddleocr
 langchain==0.0.146
-transformers==4.27.1
+transformers==4.29.1
 unstructured[local-inference]
 layoutparser[layoutmodels,tesseract]
 nltk


### PR DESCRIPTION
升级transformers版本
解决MOSS模型加载错误： get_class_from_dynamic_module() missing 2 required positional arguments: 'module_file' and 'class_name'
