### PR TITLE
feat(webui): update port number in Vite config file from 1002 to 8090

### DIFF
--- a/views/vite.config.ts
+++ b/views/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig((env) => {
     plugins: setupPlugins(viteEnv),
     server: {
       host: '0.0.0.0',
-      port: 1002,
+      port: 8090,
       open: false,
       proxy: {
         '/api': {


### PR DESCRIPTION
服务启动在 1024 以下的端口需要 root 权限，使用 1024 以上的端口会更方便