### PR TITLE
修复api接口websocket的伪流式输出

### DIFF
--- a/api.py
+++ b/api.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from typing import List, Optional
 import urllib
-
+import asyncio
 import nltk
 import pydantic
 import uvicorn
@@ -324,6 +324,7 @@ async def stream_chat(websocket: WebSocket, knowledge_base_id: str):
         for resp, history in local_doc_qa.get_knowledge_based_answer(
                 query=question, vs_path=vs_path, chat_history=history, streaming=True
         ):
+            await asyncio.sleep(0)
             await websocket.send_text(resp["result"][last_print_len:])
             last_print_len = len(resp["result"])
 


### PR DESCRIPTION
不清楚是不是因为websocket的问题。

在使用postman连接ws接口时，虽然发送的信息还是流式的，但是并不实时，获取推理结果时会最后一起拿到几十条。

因此在流式推理结果send前添加sleep，类似于nextTick这样的操作，使得推理结果会实时返回，达到真流式输出的结果。

修复后，经测试，postman可以顺畅的实时接受流式结果。