### PR TITLE
解决vue前端镜像构建失败的问题

### DIFF
--- a/views/Dockerfile
+++ b/views/Dockerfile
@@ -15,7 +15,7 @@ COPY . /app
 
 RUN pnpm run build
 
-
+FROM frontend AS final
 
 COPY --from=frontend /app/dist /app/public
 


### PR DESCRIPTION
问题出现在`COPY --from=frontend /app/dist /app/public`
导致该问题的原因应该是无法在当前构建阶段（这里是frontend）修改该阶段的镜像，所以在这行代码前添加了另一个构建阶段（final），经测试可以成功构建前端镜像并正确运行。