### PR TITLE
fix Non-UTF-8 code starting with \xe5

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,3 +1,4 @@
+#encoding:utf-8
 import argparse
 import json
 import os


### PR DESCRIPTION
修改windows11 运行api.py 报 fix Non-UTF-8 code starting with ‘\xe5’ 的错误  issue #848 
 
