### PR TITLE
Fix LocalDocQA object has no attribute llm when adding docs

### DIFF
--- a/webui_st.py
+++ b/webui_st.py
@@ -150,7 +150,7 @@ def get_vector_store(local_doc_qa, vs_id, files, sentence_size, history, one_con
     filelist = []
     if not os.path.exists(os.path.join(KB_ROOT_PATH, vs_id, "content")):
         os.makedirs(os.path.join(KB_ROOT_PATH, vs_id, "content"))
-    if local_doc_qa.llm and local_doc_qa.embeddings:
+    if local_doc_qa.llm_model_chain and local_doc_qa.embeddings:
         if isinstance(files, list):
             for file in files:
                 filename = os.path.split(file.name)[-1]


### PR DESCRIPTION
Got below errors when adding docs :
```shell
AttributeError: 'LocalDocQA' object has no attribute 'llm'
2023-07-16 10:23:09.182 Uncaught app exception
Traceback (most recent call last):
  File "/Users/ben/opt/miniconda3/envs/langchain-chatglm/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 565, in _run_script
    exec(code, module.__dict__)
  File "/Users/ben/src/ai/llms/langchain-ChatGLM/webui_st.py", line 490, in <module>
    _, _, history = load_vector_store(
  File "/Users/ben/src/ai/llms/langchain-ChatGLM/webui_st.py", line 376, in load_vector_store
    return get_vector_store(
  File "/Users/ben/src/ai/llms/langchain-ChatGLM/webui_st.py", line 153, in get_vector_store
    if local_doc_qa.llm and local_doc_qa.embeddings:
AttributeError: 'LocalDocQA' object has no attribute 'llm'
```